### PR TITLE
Add error message when site disabled

### DIFF
--- a/src/WP_Command.php
+++ b/src/WP_Command.php
@@ -30,7 +30,9 @@ class WP_Command extends EE_Command {
 		$import_export_command = false;
 
 		if ( $this->db::site_in_db( $site_name ) ) {
-
+			if ( ! $this->db::select( array( 'is_enabled' ), array( 'sitename' => $site_name ) )[0]['is_enabled'] ) {
+				EE::error( "Please enable $site_name using `ee site enable $site_name` command to run wp commands." );
+			}
 			$arguments = '';
 			if ( ! empty( $assoc_args ) ) {
 				foreach ( $assoc_args as $key => $value ) {


### PR DESCRIPTION
Currently it is trying to exec into the docker container and if the site is disabled, docker was throwing a no container found error. 
This update will show error message when site is disabled and `wp` command is invoked and halt execution there itself, hence it will not reach till docker exec.